### PR TITLE
CoapConnection campo client protected per configurazioni personalizzate

### DIFF
--- a/unibo.basicomm23/src/unibo/basicomm23/coap/CoapConnection.java
+++ b/unibo.basicomm23/src/unibo/basicomm23/coap/CoapConnection.java
@@ -11,7 +11,7 @@ import unibo.basicomm23.utils.Connection;
 
 
 public class CoapConnection extends Connection {
-private CoapClient client;
+protected CoapClient client;
 private String url;
  
 private String answer = "unknown";


### PR DESCRIPTION
Potrebbe rendersi necessaria la modifica del timeout di default, da lei impostato a 1 secondo, per gestire richieste che richiedono molto tempo per ottenere risposta.